### PR TITLE
Move reactify to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "atoa": "1.0.0",
-    "dragula": "3.6.3",
-    "reactify": "1.1.1"
+    "dragula": "3.6.3"
   },
   "devDependencies": {
     "browserify": "11.0.0",
@@ -40,6 +39,7 @@
     "jshint-stylish": "2.0.1",
     "nib": "1.1.0",
     "react": "0.13.3",
+    "reactify": "1.1.1",
     "stylus": "0.52.0",
     "uglify-js": "2.4.24",
     "watchify": "3.3.0"


### PR DESCRIPTION
`reactify` is used for the development/build process and isn't needed for production.

For regular installs, this has the benefit of simplifying the dependency tree significantly:

``` diff
 ├── atoa@1.0.0 
 ├─┬ dragula@3.6.3 
 │ ├─┬ contra@1.9.1 
 │ │ └── ticky@1.0.0 
 │ └─┬ crossvent@1.5.4 
 │   └── custom-event@1.0.0 
-└─┬ reactify@1.1.1 
-  ├─┬ react-tools@0.13.3 
-  │ ├─┬ commoner@0.10.4 
-  │ │ ├─┬ commander@2.9.0 
-  │ │ │ └── graceful-readlink@1.0.1 
-  │ │ ├─┬ detective@4.3.1 
-  │ │ │ ├── acorn@1.2.2 
-  │ │ │ └── defined@1.0.0 
-  │ │ ├─┬ glob@5.0.15 
-  │ │ │ ├─┬ inflight@1.0.4 
-  │ │ │ │ └── wrappy@1.0.1 
-  │ │ │ ├── inherits@2.0.1 
-  │ │ │ ├─┬ minimatch@3.0.0 
-  │ │ │ │ └─┬ brace-expansion@1.1.2 
-  │ │ │ │   ├── balanced-match@0.3.0 
-  │ │ │ │   └── concat-map@0.0.1 
-  │ │ │ ├── once@1.3.3 
-  │ │ │ └── path-is-absolute@1.0.0 
-  │ │ ├── graceful-fs@4.1.2 
-  │ │ ├── iconv-lite@0.4.13 
-  │ │ ├─┬ mkdirp@0.5.1 
-  │ │ │ └── minimist@0.0.8 
-  │ │ ├── private@0.1.6 
-  │ │ ├── q@1.4.1 
-  │ │ └─┬ recast@0.10.43 
-  │ │   ├── ast-types@0.8.15 
-  │ │   ├── esprima-fb@15001.1001.0-dev-harmony-fb 
-  │ │   └── source-map@0.5.3 
-  │ └─┬ jstransform@10.1.0 
-  │   ├── base62@0.1.1 
-  │   ├── esprima-fb@13001.1001.0-dev-harmony-fb 
-  │   └─┬ source-map@0.1.31 
-  │     └── amdefine@1.0.0 
-  └── through@2.3.8
```
