### PR TITLE
Alternative React implementation example using refs (ES2015 syntax)

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -61,6 +61,7 @@ Here's an example using refs (ES2015 syntax):  [React: The ref Callback Attribut
 
 ```jsx
 import * as React from "react";
+import * as ReactDOM from 'react-dom';
 import Dragula from 'react-dragula';
 export class App extends React.Component {
   render () {
@@ -81,7 +82,7 @@ export class App extends React.Component {
     }
   };
 });
-React.render(<App />, document.getElementById('examples'));
+ReactDOM.render(<App />, document.getElementById('examples'));
 ```
 
 # License

--- a/readme.markdown
+++ b/readme.markdown
@@ -55,6 +55,35 @@ var App = React.createClass({
 React.render(<App />, document.getElementById('examples'));
 ```
 
+# Example using refs (ES2015 syntax)
+
+Here's an example using refs (ES2015 syntax):  [React: The ref Callback Attribute](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute)
+
+```jsx
+import * as React from "react";
+import Dragula from 'react-dragula';
+export class App extends React.Component {
+  render () {
+    return <div className='container' ref={this.dragulaDecorator}>
+      <div>Swap me around</div>
+      <div>Swap her around</div>
+      <div>Swap him around</div>
+      <div>Swap them around</div>
+      <div>Swap us around</div>
+      <div>Swap things around</div>
+      <div>Swap everything around</div>
+    </div>;
+  },
+  dragulaDecorator = (componentBackingInstance) => {
+    if (componentBackingInstance) {
+      let options = { };
+      Dragula([componentBackingInstance], options);
+    }
+  };
+});
+React.render(<App />, document.getElementById('examples'));
+```
+
 # License
 
 MIT


### PR DESCRIPTION
- missing ReactDOM import
- Alternative React implementation example using refs (ES2015 syntax)

Using ReactDOM.findDOMNode is discouraged by facebook

> you can use ReactDOM.findDOMNode as an "escape hatch" but we don't recommend it since it breaks encapsulation

I'm providing an alternative React implementation using ES2015 / TypeScript syntax "using refs", actually it's the preferred (by facebook) "escape hatch" to underlaying DOM nodes: [React: The ref Callback Attribute](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute)

``` jsx
import * as React from "react";
import * as ReactDOM from 'react-dom';
import Dragula from 'react-dragula';
export class App extends React.Component {
  render () {
    return <div className='container' ref={this.dragulaDecorator}>
      <div>Swap me around</div>
      <div>Swap her around</div>
      <div>Swap him around</div>
      <div>Swap them around</div>
      <div>Swap us around</div>
      <div>Swap things around</div>
      <div>Swap everything around</div>
    </div>;
  },
  dragulaDecorator = (componentBackingInstance) => {
    if (componentBackingInstance) {
      let options = { };
      Dragula([componentBackingInstance], options);
    }
  };
});
ReactDOM.render(<App />, document.getElementById('examples'));
```
